### PR TITLE
Add serialization method to SolidusGlobalize::Globalize::AttributeMethods

### DIFF
--- a/lib/patches/attribute_methods/serialization.rb
+++ b/lib/patches/attribute_methods/serialization.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SolidusGlobalize
+  module AttributeMethods
+    module Serialization
+      def serialize(attr_name, coder: nil, type: Object, yaml: {}, **options)
+        options[:coder] = coder if coder
+        options[:type] = type if type
+
+        super(attr_name, **options)
+      end
+
+      ::Globalize::AttributeMethods::Serialization.prepend self
+    end
+  end
+end

--- a/lib/solidus_globalize.rb
+++ b/lib/solidus_globalize.rb
@@ -9,3 +9,5 @@ require 'solidus_globalize/engine'
 require 'deface'
 require 'solidus_globalize/configuration'
 require 'solidus_globalize/fallbacks'
+
+require 'patches/attribute_methods/serialization'


### PR DESCRIPTION
solidusのSpree::Preferences::Persistableでserializeの分岐の際にメソッドの引数で判断しているのに対応するため、オーバーライドする