### PR TITLE
Modify serialization method

### DIFF
--- a/lib/patches/attribute_methods/serialization.rb
+++ b/lib/patches/attribute_methods/serialization.rb
@@ -3,8 +3,7 @@
 module SolidusGlobalize
   module AttributeMethods
     module Serialization
-      def serialize(attr_name, coder: nil, type: Object, yaml: {}, **options)
-        options[:coder] = coder if coder
+      def serialize(attr_name, type: Object, **options)
         options[:type] = type if type
 
         super(attr_name, **options)


### PR DESCRIPTION
stagingとproductionで上手くいかなかったのでこちらで試してみます。

自分の理解だと、`globalize` gemは rails 7.2の`serialize` methodに更新されているものの、
solidusの`persistable.rb`がまだ対応出来ていない模様という理解です。